### PR TITLE
Fix duplicate toast listener

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -177,7 +177,9 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+    // We only want to register the listener once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent duplicate listeners in `useToast`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3c56994c832ca9b68e526894d185