### PR TITLE
Add audit log context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { AuditLogProvider } from "@/contexts/AuditLogContext";
 import { UserProvider } from "@/contexts/UserContext";
 
 // Lazy load page components
@@ -19,6 +20,7 @@ const Tables = lazy(() => import("./pages/Tables"));
 const Inventory = lazy(() => import("./pages/Inventory"));
 const Users = lazy(() => import("./pages/Users"));
 const Reports = lazy(() => import("./pages/Reports"));
+const AuditLog = lazy(() => import("./pages/AuditLog"));
 const Login = lazy(() => import("./pages/Login"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
@@ -40,83 +42,93 @@ const queryClient = new QueryClient();
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <UserProvider>
-      <TooltipProvider>
-        <Toaster />
-        <Sonner />
-        <HashRouter>
-          <Suspense fallback={<PageLoading />}>
-            <Routes>
-              <Route path="/login" element={<Login />} />
-              <Route
-                path="/"
-                element={
-                  <ProtectedRoute requiredPage="dashboard">
-                    <Dashboard />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/dashboard"
-                element={
-                  <ProtectedRoute requiredPage="dashboard">
-                    <Dashboard />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/orders"
-                element={
-                  <ProtectedRoute requiredPage="orders">
-                    <Orders />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/menu"
-                element={
-                  <ProtectedRoute requiredPage="menu">
-                    <Menu />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/tables"
-                element={
-                  <ProtectedRoute requiredPage="tables">
-                    <Tables />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/inventory"
-                element={
-                  <ProtectedRoute requiredPage="inventory">
-                    <Inventory />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/users"
-                element={
-                  <ProtectedRoute requiredPage="users">
-                    <Users />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/reports"
-                element={
-                  <ProtectedRoute requiredPage="reports">
-                    <Reports />
-                  </ProtectedRoute>
-                }
-              />
-              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </Suspense>
-        </HashRouter>
-      </TooltipProvider>
+      <AuditLogProvider>
+        <TooltipProvider>
+          <Toaster />
+          <Sonner />
+          <HashRouter>
+            <Suspense fallback={<PageLoading />}>
+              <Routes>
+                <Route path="/login" element={<Login />} />
+                <Route
+                  path="/"
+                  element={
+                    <ProtectedRoute requiredPage="dashboard">
+                      <Dashboard />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/dashboard"
+                  element={
+                    <ProtectedRoute requiredPage="dashboard">
+                      <Dashboard />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/orders"
+                  element={
+                    <ProtectedRoute requiredPage="orders">
+                      <Orders />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/menu"
+                  element={
+                    <ProtectedRoute requiredPage="menu">
+                      <Menu />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/tables"
+                  element={
+                    <ProtectedRoute requiredPage="tables">
+                      <Tables />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/inventory"
+                  element={
+                    <ProtectedRoute requiredPage="inventory">
+                      <Inventory />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/users"
+                  element={
+                    <ProtectedRoute requiredPage="users">
+                      <Users />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/reports"
+                  element={
+                    <ProtectedRoute requiredPage="reports">
+                      <Reports />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/audit-log"
+                  element={
+                    <ProtectedRoute requiredPage="audit-log">
+                      <AuditLog />
+                    </ProtectedRoute>
+                  }
+                />
+                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </Suspense>
+          </HashRouter>
+        </TooltipProvider>
+      </AuditLogProvider>
     </UserProvider>
   </QueryClientProvider>
 );

--- a/src/contexts/AuditLogContext.tsx
+++ b/src/contexts/AuditLogContext.tsx
@@ -1,0 +1,67 @@
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+import { useUser } from "@/contexts/UserContext";
+
+export interface AuditLogEntry {
+  action: string;
+  user: string;
+  timestamp: string;
+}
+
+interface AuditLogContextType {
+  logs: AuditLogEntry[];
+  recordAction: (action: string) => void;
+}
+
+const AuditLogContext = createContext<AuditLogContextType | undefined>(
+  undefined,
+);
+
+export function AuditLogProvider({ children }: { children: ReactNode }) {
+  const { currentUser } = useUser();
+  const [logs, setLogs] = useState<AuditLogEntry[]>(() => {
+    const stored = localStorage.getItem("auditLogs");
+    if (stored) {
+      try {
+        return JSON.parse(stored);
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem("auditLogs", JSON.stringify(logs));
+  }, [logs]);
+
+  const recordAction = (action: string) => {
+    if (!currentUser) return;
+    const entry: AuditLogEntry = {
+      action,
+      user: currentUser.name,
+      timestamp: new Date().toISOString(),
+    };
+    setLogs((prev) => [...prev, entry]);
+  };
+
+  return (
+    <AuditLogContext.Provider value={{ logs, recordAction }}>
+      {children}
+    </AuditLogContext.Provider>
+  );
+}
+
+export function useAuditLog() {
+  const context = useContext(AuditLogContext);
+  if (!context) {
+    throw new Error("useAuditLog must be used within an AuditLogProvider");
+  }
+  return context;
+}

--- a/src/lib/role-permissions.spec.ts
+++ b/src/lib/role-permissions.spec.ts
@@ -19,6 +19,7 @@ describe("hasPageAccess", () => {
       "inventory",
       "users",
       "reports",
+      "audit-log",
     ];
     pages.forEach((page) => {
       expect(hasPageAccess("Administrator", page)).toBe(true);
@@ -67,6 +68,7 @@ describe("getNavigationItems", () => {
       "inventory",
       "users",
       "reports",
+      "audit-log",
     ]);
   });
 

--- a/src/lib/role-permissions.ts
+++ b/src/lib/role-permissions.ts
@@ -26,6 +26,7 @@ export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
     },
     { page: "users", actions: ["create", "view", "edit", "delete"] },
     { page: "reports", actions: ["view", "export"] },
+    { page: "audit-log", actions: ["view"] },
   ],
   Manager: [
     { page: "dashboard" },
@@ -79,6 +80,12 @@ export const NAVIGATION_ITEMS = [
     href: "/reports",
     icon: "BarChart3",
     requiredPage: "reports",
+  },
+  {
+    name: "Audit Log",
+    href: "/audit-log",
+    icon: "ListChecks",
+    requiredPage: "audit-log",
   },
 ];
 

--- a/src/pages/AuditLog.tsx
+++ b/src/pages/AuditLog.tsx
@@ -1,0 +1,31 @@
+import { RestaurantLayout } from "@/components/restaurant/RestaurantLayout";
+import { useAuditLog } from "@/contexts/AuditLogContext";
+
+export default function AuditLog() {
+  const { logs } = useAuditLog();
+
+  return (
+    <RestaurantLayout>
+      <div className="p-4 space-y-4">
+        <h1 className="text-2xl font-bold">Audit Log</h1>
+        {logs.length === 0 ? (
+          <p>No actions recorded.</p>
+        ) : (
+          <ul className="space-y-2">
+            {logs
+              .slice()
+              .reverse()
+              .map((log, idx) => (
+                <li key={idx} className="border rounded-md p-2">
+                  <div className="font-medium">{log.action}</div>
+                  <div className="text-sm text-gray-500">
+                    {log.user} - {new Date(log.timestamp).toLocaleString()}
+                  </div>
+                </li>
+              ))}
+          </ul>
+        )}
+      </div>
+    </RestaurantLayout>
+  );
+}

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -36,6 +36,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { SwipeToAction } from "@/components/ui/swipe-to-action";
+import { useAuditLog } from "@/contexts/AuditLogContext";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { usePullToRefresh } from "@/hooks/use-pull-to-refresh";
 import { InventoryItem } from "@/lib/mock-data";
@@ -52,6 +53,7 @@ export default function Inventory() {
   const [selectedItem, setSelectedItem] = useState<InventoryItem | null>(null);
   const [editingItem, setEditingItem] = useState<InventoryItem | null>(null);
   const isMobile = useIsMobile();
+  const { recordAction } = useAuditLog();
 
   // Form state for new items
   const [formData, setFormData] = useState({
@@ -170,10 +172,12 @@ export default function Inventory() {
         setInventory((prev) =>
           prev.map((item) => (item.id === editingItem.id ? updatedItem : item)),
         );
+        recordAction(`Updated inventory item ${updatedItem.name}`);
       } else {
         // Add new item
         const newItem = await RestaurantService.addInventoryItem(itemData);
         setInventory((prev) => [...prev, newItem]);
+        recordAction(`Added inventory item ${newItem.name}`);
       }
 
       resetForm();
@@ -198,6 +202,7 @@ export default function Inventory() {
       setInventory((prev) =>
         prev.map((item) => (item.id === selectedItem.id ? updatedItem : item)),
       );
+      recordAction(`Restocked item ${updatedItem.name}`);
 
       // Reset form
       setRestockData({ quantity: "", cost: "" });
@@ -233,6 +238,7 @@ export default function Inventory() {
     try {
       // Simulate delete by removing from local state
       setInventory((prev) => prev.filter((item) => item.id !== itemId));
+      recordAction(`Deleted inventory item ${itemId}`);
     } catch (error) {
       console.error("Failed to delete inventory item:", error);
     }

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -48,6 +48,7 @@ import {
 import { SwipeToAction } from "@/components/ui/swipe-to-action";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { useAuditLog } from "@/contexts/AuditLogContext";
 import { useUser } from "@/contexts/UserContext";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { usePullToRefresh } from "@/hooks/use-pull-to-refresh";
@@ -63,6 +64,7 @@ interface NewOrderItem {
 
 export default function Orders() {
   const { currentUser } = useUser();
+  const { recordAction } = useAuditLog();
   const [searchParams, setSearchParams] = useSearchParams();
   const isMobile = useIsMobile();
 
@@ -339,6 +341,7 @@ export default function Orders() {
 
       const createdOrder = await RestaurantService.createOrder(orderData);
       setOrders((prev) => [createdOrder, ...prev]);
+      recordAction(`Created order ${createdOrder.id}`);
 
       // Reset form
       setNewOrder({ tableNumber: "", serverName: "", notes: "" });


### PR DESCRIPTION
## Summary
- implement `AuditLogContext` with provider and hook
- log key actions on orders and inventory changes
- add Audit Log page and navigation entry
- restrict access to logs for administrators
- update role permission tests

## Testing
- `npm run lint`
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685d4f37c460832c802fe8455da2b0b4