### PR TITLE
Adjust CI trigger for PRs only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: ["**"]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- run CI workflow only on pull requests to avoid redundant runs after merge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d56a5de88832c927b25bc4b780822