### PR TITLE
Use CI artifacts for GitHub Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -31,4 +34,10 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: ./dist
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,11 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types:
+      - completed
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -12,34 +14,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    if: github.ref == 'refs/heads/main'
+  deploy:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-
+    permissions:
+      pages: write
+      id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          node-version: "18"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Type check
-        run: npm run typecheck
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Run tests
-        run: npm run test
-
-      - name: Build
-        run: npm run build
+          name: dist
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ./dist
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -49,17 +36,9 @@ jobs:
         with:
           path: "./dist"
 
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      pages: write
-      id-token: write
-    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -355,6 +355,22 @@ npm run test
 
 Test files should be placed alongside source files with `.test.ts` or `.spec.ts` extensions.
 
+## 📝 Linting
+
+Check code quality with:
+
+```bash
+npm run lint
+```
+
+## 🏗️ Build
+
+Create a production build with:
+
+```bash
+npm run build
+```
+
 ## 📱 Responsive Design
 
 The application is fully responsive and optimized for:
@@ -405,8 +421,8 @@ This project is configured for automatic deployment to GitHub Pages using GitHub
 
 #### Automatic Deployment:
 
-- **Trigger**: Every push to the `main` branch
-- **Process**: Build → Test → Lint → Deploy
+- **Trigger**: Successful `CI` workflow on the `main` branch
+- **Process**: CI builds and uploads artifacts → Deploy workflow publishes them
 - **URL**: `https://ramiz4.github.io/restaurant-pro/`
 
 #### Manual Deployment:
@@ -421,11 +437,7 @@ npm run preview
 
 The deployment workflow includes:
 
-- ✅ Dependency installation
-- ✅ TypeScript type checking
-- ✅ ESLint code quality checks
-- ✅ Test execution
-- ✅ Production build
+- ✅ Downloading build artifacts from CI
 - ✅ Automatic deployment to GitHub Pages
 
 ## 🤝 Contributing


### PR DESCRIPTION
## Summary
- upload build artifacts from the CI workflow
- trigger deployment workflow on successful CI run
- reuse the uploaded build artifacts to deploy
- document lint and build commands in the README

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d9393232c832c99d8c8130b3aac0f