### PR TITLE
Add customizable RBAC roles with inheritance

### DIFF
--- a/src/lib/role-permissions.spec.ts
+++ b/src/lib/role-permissions.spec.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   UserRole,
+  defineRole,
   getNavigationItems,
   hasActionAccess,
   hasPageAccess,
+  resetCustomRoles,
 } from "./role-permissions";
 
 // Test suites for role-based permissions
@@ -89,5 +91,27 @@ describe("getNavigationItems", () => {
       "menu",
       "inventory",
     ]);
+  });
+});
+
+describe("custom roles", () => {
+  afterEach(() => {
+    resetCustomRoles();
+  });
+
+  it("allows creating a role with no inheritance", () => {
+    defineRole("Guest", { permissions: [{ page: "dashboard" }] });
+    expect(hasPageAccess("Guest", "dashboard")).toBe(true);
+    expect(hasPageAccess("Guest", "orders")).toBe(false);
+  });
+
+  it("supports permission inheritance", () => {
+    defineRole("Supervisor", {
+      inherits: ["Server"],
+      permissions: [{ page: "reports", actions: ["view"] }],
+    });
+    expect(hasPageAccess("Supervisor", "orders")).toBe(true); // from Server
+    expect(hasActionAccess("Supervisor", "reports", "view")).toBe(true);
+    expect(hasActionAccess("Supervisor", "reports", "export")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- extend `role-permissions.ts` to allow defining custom roles
- add permission inheritance resolution helpers
- update existing permission checks to use dynamic permissions
- test custom role creation and inheritance

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685dac56a504832c84727199f532c503