### PR TITLE
Implement Staff Scheduling Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ A modern, full-featured restaurant management application built with React, Type
 - **Real-time Updates**: Live data synchronization
 - **Real-time Notifications**: Role-specific alerts for new orders and low stock
 - **Online Ordering Interface**: Customers can place orders directly from a dedicated page
+- **Staff Scheduling**: Manage staff shifts with role-based permissions
 - **Search & Filtering**: Advanced search capabilities across all modules
 - **Modern UI**: Clean, intuitive interface built with shadcn/ui components
 - **Accessibility**: WCAG compliant design
@@ -405,7 +406,7 @@ The application is fully responsive and optimized for:
 - **Integration with POS Systems**: Enterprise-grade point of sale integration
 - **Customer Feedback System**: Role-based customer interaction management
 - **Online Ordering Integration**: _Implemented_ - Customers can submit orders online
-- **Staff Scheduling Module**: Role-based schedule management
+- **Staff Scheduling Module**: _Implemented_ - Role-based schedule management
 - **Supplier Management**: Vendor relationships with permission controls
 
 ## 🚀 Deployment
@@ -474,6 +475,7 @@ For support and questions:
 - [Radix UI](https://www.radix-ui.com/) for accessible primitives
 - [Lucide](https://lucide.dev/) for the icon library
 - [Tailwind CSS](https://tailwindcss.com/) for the styling framework
+- Personal thanks to the **Fusion Starter** template (see `CLAUDE.md`) whose design choices inspired our React, Tailwind, and testing setup
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ const Users = lazy(() => import("./pages/Users"));
 const Reports = lazy(() => import("./pages/Reports"));
 const AuditLog = lazy(() => import("./pages/AuditLog"));
 const OnlineOrder = lazy(() => import("./pages/OnlineOrder"));
+const Schedule = lazy(() => import("./pages/Schedule"));
 const Login = lazy(() => import("./pages/Login"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
@@ -116,6 +117,14 @@ const App = () => (
                     element={
                       <ProtectedRoute requiredPage="reports">
                         <Reports />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/schedule"
+                    element={
+                      <ProtectedRoute requiredPage="schedule">
+                        <Schedule />
                       </ProtectedRoute>
                     }
                   />

--- a/src/components/restaurant/RestaurantLayout.tsx
+++ b/src/components/restaurant/RestaurantLayout.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import {
   BarChart3,
+  CalendarCheck2,
   ChefHat,
   LayoutDashboard,
   ListChecks,
@@ -40,6 +41,7 @@ const iconMap = {
   Users,
   BarChart3,
   ListChecks,
+  CalendarCheck2,
 };
 
 export function RestaurantLayout({ children }: RestaurantLayoutProps) {

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -82,6 +82,14 @@ export interface SalesReport {
   topItems: { item: string; quantity: number; revenue: number }[];
 }
 
+export interface Shift {
+  id: string;
+  userId: string;
+  role: User["role"];
+  start: Date;
+  end: Date;
+}
+
 // Mock Data
 export const mockMenuItems: MenuItem[] = [
   // Appetizers
@@ -1231,5 +1239,43 @@ export const mockSalesData: SalesReport[] = [
       { item: "Grilled Salmon", quantity: 10, revenue: 249.9 },
       { item: "Chocolate Cake", quantity: 18, revenue: 161.82 },
     ],
+  },
+];
+
+export const mockShifts: Shift[] = [
+  {
+    id: "SHIFT-001",
+    userId: "1",
+    role: "server",
+    start: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    end: new Date(Date.now() + 10 * 60 * 60 * 1000),
+  },
+  {
+    id: "SHIFT-002",
+    userId: "2",
+    role: "server",
+    start: new Date(Date.now() + 12 * 60 * 60 * 1000),
+    end: new Date(Date.now() + 20 * 60 * 60 * 1000),
+  },
+  {
+    id: "SHIFT-003",
+    userId: "3",
+    role: "manager",
+    start: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    end: new Date(Date.now() + 32 * 60 * 60 * 1000),
+  },
+  {
+    id: "SHIFT-004",
+    userId: "4",
+    role: "kitchen",
+    start: new Date(Date.now() + 36 * 60 * 60 * 1000),
+    end: new Date(Date.now() + 44 * 60 * 60 * 1000),
+  },
+  {
+    id: "SHIFT-005",
+    userId: "5",
+    role: "admin",
+    start: new Date(Date.now() + 48 * 60 * 60 * 1000),
+    end: new Date(Date.now() + 56 * 60 * 60 * 1000),
   },
 ];

--- a/src/lib/restaurant-services.ts
+++ b/src/lib/restaurant-services.ts
@@ -4,6 +4,7 @@ import {
   type Order,
   type Payment,
   type SalesReport,
+  type Shift,
   type Table,
   type User,
   mockInventory,
@@ -11,6 +12,7 @@ import {
   mockOrders,
   mockPayments,
   mockSalesData,
+  mockShifts,
   mockTables,
   mockUsers,
 } from "./mock-data";
@@ -309,6 +311,47 @@ export class RestaurantService {
   static async getPaymentByOrderId(orderId: string): Promise<Payment | null> {
     await delay(200);
     return mockPayments.find((payment) => payment.orderId === orderId) || null;
+  }
+
+  // Shifts
+  static async getShifts(): Promise<Shift[]> {
+    await delay(200);
+    return [...mockShifts].sort(
+      (a, b) => a.start.getTime() - b.start.getTime(),
+    );
+  }
+
+  static async createShift(shift: Omit<Shift, "id">): Promise<Shift> {
+    await delay(300);
+    const newShift: Shift = {
+      ...shift,
+      id: `SHIFT-${String(mockShifts.length + 1).padStart(3, "0")}`,
+    };
+    mockShifts.push(newShift);
+    return newShift;
+  }
+
+  static async updateShift(
+    id: string,
+    updates: Partial<Shift>,
+  ): Promise<Shift> {
+    await delay(300);
+    const idx = mockShifts.findIndex((s) => s.id === id);
+    if (idx !== -1) {
+      mockShifts[idx] = { ...mockShifts[idx], ...updates };
+      return mockShifts[idx];
+    }
+    throw new Error("Shift not found");
+  }
+
+  static async deleteShift(id: string): Promise<void> {
+    await delay(200);
+    const idx = mockShifts.findIndex((s) => s.id === id);
+    if (idx !== -1) {
+      mockShifts.splice(idx, 1);
+    } else {
+      throw new Error("Shift not found");
+    }
   }
 }
 

--- a/src/lib/role-permissions.spec.ts
+++ b/src/lib/role-permissions.spec.ts
@@ -70,6 +70,7 @@ describe("getNavigationItems", () => {
       "inventory",
       "users",
       "reports",
+      "schedule",
       "audit-log",
     ]);
   });
@@ -81,6 +82,7 @@ describe("getNavigationItems", () => {
       "menu",
       "tables",
       "inventory",
+      "schedule",
     ]);
   });
 
@@ -90,6 +92,7 @@ describe("getNavigationItems", () => {
       "orders",
       "menu",
       "inventory",
+      "schedule",
     ]);
   });
 });

--- a/src/lib/role-permissions.ts
+++ b/src/lib/role-permissions.ts
@@ -39,6 +39,7 @@ export const DEFAULT_ROLE_DEFINITIONS: Record<DefaultUserRole, RoleDefinition> =
         },
         { page: "users", actions: ["create", "view", "edit", "delete"] },
         { page: "reports", actions: ["view", "export"] },
+        { page: "schedule", actions: ["create", "view", "edit", "delete"] },
         { page: "audit-log", actions: ["view"] },
       ],
     },
@@ -51,6 +52,7 @@ export const DEFAULT_ROLE_DEFINITIONS: Record<DefaultUserRole, RoleDefinition> =
         { page: "inventory", actions: ["view", "edit", "restock"] },
         { page: "users", actions: ["view"] },
         { page: "reports", actions: ["view", "export"] },
+        { page: "schedule", actions: ["create", "view", "edit", "delete"] },
       ],
     },
     Server: {
@@ -60,6 +62,7 @@ export const DEFAULT_ROLE_DEFINITIONS: Record<DefaultUserRole, RoleDefinition> =
         { page: "menu", actions: ["view"] },
         { page: "tables", actions: ["view", "edit", "reserve"] },
         { page: "inventory", actions: ["view"] },
+        { page: "schedule", actions: ["view"] },
       ],
     },
     "Kitchen Staff": {
@@ -68,6 +71,7 @@ export const DEFAULT_ROLE_DEFINITIONS: Record<DefaultUserRole, RoleDefinition> =
         { page: "orders", actions: ["view", "edit"] }, // Can update order status
         { page: "menu", actions: ["view"] },
         { page: "inventory", actions: ["view"] },
+        { page: "schedule", actions: ["view"] },
       ],
     },
   };
@@ -160,6 +164,12 @@ export const NAVIGATION_ITEMS = [
     href: "/reports",
     icon: "BarChart3",
     requiredPage: "reports",
+  },
+  {
+    name: "Schedule",
+    href: "/schedule",
+    icon: "CalendarCheck2",
+    requiredPage: "schedule",
   },
   {
     name: "Audit Log",

--- a/src/pages/Schedule.spec.tsx
+++ b/src/pages/Schedule.spec.tsx
@@ -1,0 +1,52 @@
+import { MemoryRouter } from "react-router-dom";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useUser } from "@/contexts/UserContext";
+import { cleanup, render } from "@/test-utils/react-testing-library";
+
+import Schedule from "./Schedule";
+
+vi.mock("@/contexts/UserContext", () => ({
+  useUser: vi.fn(),
+}));
+const mockedUseUser = vi.mocked(useUser);
+
+vi.mock("@/components/restaurant/RestaurantLayout", () => ({
+  RestaurantLayout: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/contexts/AuditLogContext", () => ({
+  useAuditLog: () => ({ recordAction: vi.fn() }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Schedule page", () => {
+  it("renders heading", () => {
+    const adminUser = {
+      name: "Admin",
+      email: "admin@example.com",
+      role: "Administrator" as const,
+      initials: "AD",
+      roleColor: "text-red-500",
+    };
+    const mockContext: ReturnType<typeof useUser> = {
+      currentUser: adminUser,
+      setCurrentUser: vi.fn(),
+      logout: vi.fn(),
+      isLoading: false,
+    };
+    mockedUseUser.mockReturnValue(mockContext);
+    const { container } = render(
+      <MemoryRouter>
+        <Schedule />
+      </MemoryRouter>,
+    );
+    expect(container.innerHTML.length).toBeGreaterThan(0);
+  });
+});

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+
+import { CalendarCheck2, Plus } from "lucide-react";
+
+import { PermissionGuard } from "@/components/restaurant/PermissionGuard";
+import { RestaurantLayout } from "@/components/restaurant/RestaurantLayout";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader as DialogHead,
+  DialogTitle as DialogTit,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAuditLog } from "@/contexts/AuditLogContext";
+import { Shift, User } from "@/lib/mock-data";
+import RestaurantService from "@/lib/restaurant-services";
+
+export default function Schedule() {
+  const [shifts, setShifts] = useState<Shift[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [formData, setFormData] = useState({ userId: "", start: "", end: "" });
+  const { recordAction } = useAuditLog();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [shiftData, userData] = await Promise.all([
+          RestaurantService.getShifts(),
+          RestaurantService.getUsers(),
+        ]);
+        setShifts(shiftData);
+        setUsers(userData.filter((u) => u.active));
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const addShift = async () => {
+    const user = users.find((u) => u.id === formData.userId);
+    if (!user) return;
+    await RestaurantService.createShift({
+      userId: user.id,
+      role: user.role,
+      start: new Date(formData.start),
+      end: new Date(formData.end),
+    });
+    recordAction("Created shift", "schedule");
+    setFormData({ userId: "", start: "", end: "" });
+    setIsAddOpen(false);
+    const data = await RestaurantService.getShifts();
+    setShifts(data);
+  };
+
+  if (loading) {
+    return (
+      <RestaurantLayout>
+        <div className="animate-pulse space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-20 bg-gray-200 rounded-lg"></div>
+          ))}
+        </div>
+      </RestaurantLayout>
+    );
+  }
+
+  return (
+    <RestaurantLayout>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <CalendarCheck2 className="h-6 w-6" /> Staff Schedule
+          </h1>
+          <PermissionGuard page="schedule" action="create">
+            <Dialog open={isAddOpen} onOpenChange={setIsAddOpen}>
+              <DialogTrigger asChild>
+                <Button size="sm">
+                  <Plus className="mr-2 h-4 w-4" /> Add Shift
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHead>
+                  <DialogTit>New Shift</DialogTit>
+                </DialogHead>
+                <div className="space-y-4 py-2">
+                  <div>
+                    <label className="block text-sm font-medium mb-1">
+                      Employee
+                    </label>
+                    <Select
+                      value={formData.userId}
+                      onValueChange={(v) =>
+                        setFormData({ ...formData, userId: v })
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select employee" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {users.map((u) => (
+                          <SelectItem key={u.id} value={u.id}>
+                            {u.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">
+                      Start
+                    </label>
+                    <Input
+                      type="datetime-local"
+                      value={formData.start}
+                      onChange={(e) =>
+                        setFormData({ ...formData, start: e.target.value })
+                      }
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">
+                      End
+                    </label>
+                    <Input
+                      type="datetime-local"
+                      value={formData.end}
+                      onChange={(e) =>
+                        setFormData({ ...formData, end: e.target.value })
+                      }
+                    />
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button onClick={addShift}>Save</Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </PermissionGuard>
+        </div>
+        <div className="grid gap-4">
+          {shifts.map((shift) => {
+            const user = users.find((u) => u.id === shift.userId);
+            return (
+              <Card
+                key={shift.id}
+                className="hover:shadow-md transition-shadow"
+              >
+                <CardHeader>
+                  <CardTitle>{user ? user.name : shift.userId}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground">
+                    {new Date(shift.start).toLocaleString()} -{" "}
+                    {new Date(shift.end).toLocaleString()}
+                  </p>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      </div>
+    </RestaurantLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add staff scheduling data structures
- add schedule service methods
- add schedule page and tests
- integrate page into navigation and routing
- document scheduling feature in README
- remove `any` in Schedule.spec
- acknowledge Fusion Starter design influence

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685db319e470832c8d17a86deeffde19