### PR TITLE
Add draggable table layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const Dashboard = lazy(() => import("./pages/Dashboard"));
 const Orders = lazy(() => import("./pages/Orders"));
 const Menu = lazy(() => import("./pages/Menu"));
 const Tables = lazy(() => import("./pages/Tables"));
+const TableLayout = lazy(() => import("./pages/TableLayout"));
 const Inventory = lazy(() => import("./pages/Inventory"));
 const Users = lazy(() => import("./pages/Users"));
 const Reports = lazy(() => import("./pages/Reports"));
@@ -93,6 +94,14 @@ const App = () => (
                     element={
                       <ProtectedRoute requiredPage="tables">
                         <Tables />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/table-layout"
+                    element={
+                      <ProtectedRoute requiredPage="table-layout">
+                        <TableLayout />
                       </ProtectedRoute>
                     }
                   />

--- a/src/lib/role-permissions.spec.ts
+++ b/src/lib/role-permissions.spec.ts
@@ -67,6 +67,7 @@ describe("getNavigationItems", () => {
       "orders",
       "menu",
       "tables",
+      "table-layout",
       "inventory",
       "users",
       "reports",
@@ -81,6 +82,7 @@ describe("getNavigationItems", () => {
       "orders",
       "menu",
       "tables",
+      "table-layout",
       "inventory",
       "schedule",
     ]);

--- a/src/lib/role-permissions.ts
+++ b/src/lib/role-permissions.ts
@@ -33,6 +33,7 @@ export const DEFAULT_ROLE_DEFINITIONS: Record<DefaultUserRole, RoleDefinition> =
           page: "tables",
           actions: ["create", "view", "edit", "delete", "reserve"],
         },
+        { page: "table-layout", actions: ["view", "edit"] },
         {
           page: "inventory",
           actions: ["create", "view", "edit", "delete", "restock"],
@@ -49,6 +50,7 @@ export const DEFAULT_ROLE_DEFINITIONS: Record<DefaultUserRole, RoleDefinition> =
         { page: "orders", actions: ["create", "view", "edit", "payment"] },
         { page: "menu", actions: ["create", "view", "edit", "delete"] },
         { page: "tables", actions: ["view", "edit", "reserve"] },
+        { page: "table-layout", actions: ["view", "edit"] },
         { page: "inventory", actions: ["view", "edit", "restock"] },
         { page: "users", actions: ["view"] },
         { page: "reports", actions: ["view", "export"] },
@@ -61,6 +63,7 @@ export const DEFAULT_ROLE_DEFINITIONS: Record<DefaultUserRole, RoleDefinition> =
         { page: "orders", actions: ["create", "view", "edit"] },
         { page: "menu", actions: ["view"] },
         { page: "tables", actions: ["view", "edit", "reserve"] },
+        { page: "table-layout", actions: ["view", "edit"] },
         { page: "inventory", actions: ["view"] },
         { page: "schedule", actions: ["view"] },
       ],
@@ -152,6 +155,12 @@ export const NAVIGATION_ITEMS = [
   },
   { name: "Menu", href: "/menu", icon: "MenuIcon", requiredPage: "menu" },
   { name: "Tables", href: "/tables", icon: "ChefHat", requiredPage: "tables" },
+  {
+    name: "Table Layout",
+    href: "/table-layout",
+    icon: "LayoutDashboard",
+    requiredPage: "table-layout",
+  },
   {
     name: "Inventory",
     href: "/inventory",

--- a/src/pages/TableLayout.spec.tsx
+++ b/src/pages/TableLayout.spec.tsx
@@ -1,0 +1,52 @@
+import { MemoryRouter } from "react-router-dom";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useUser } from "@/contexts/UserContext";
+import { cleanup, render } from "@/test-utils/react-testing-library";
+
+import TableLayout from "./TableLayout";
+
+vi.mock("@/contexts/UserContext", () => ({
+  useUser: vi.fn(),
+}));
+const mockedUseUser = vi.mocked(useUser);
+
+vi.mock("@/components/restaurant/RestaurantLayout", () => ({
+  RestaurantLayout: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/contexts/AuditLogContext", () => ({
+  useAuditLog: () => ({ recordAction: vi.fn() }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TableLayout page", () => {
+  it("renders heading", () => {
+    const adminUser = {
+      name: "Admin",
+      email: "admin@example.com",
+      role: "Administrator" as const,
+      initials: "AD",
+      roleColor: "text-red-500",
+    };
+    const mockContext: ReturnType<typeof useUser> = {
+      currentUser: adminUser,
+      setCurrentUser: vi.fn(),
+      logout: vi.fn(),
+      isLoading: false,
+    };
+    mockedUseUser.mockReturnValue(mockContext);
+    const { container } = render(
+      <MemoryRouter>
+        <TableLayout />
+      </MemoryRouter>,
+    );
+    expect(container.innerHTML.length).toBeGreaterThan(0);
+  });
+});

--- a/src/pages/TableLayout.tsx
+++ b/src/pages/TableLayout.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+
+import { PermissionGuard } from "@/components/restaurant/PermissionGuard";
+import { RestaurantLayout } from "@/components/restaurant/RestaurantLayout";
+import { Badge } from "@/components/ui/badge";
+import { Table } from "@/lib/mock-data";
+import RestaurantService from "@/lib/restaurant-services";
+import { cn } from "@/lib/utils";
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+export default function TableLayout() {
+  const [tables, setTables] = useState<Table[]>([]);
+  const [positions, setPositions] = useState<Record<string, Position>>({});
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await RestaurantService.getTables();
+      setTables(data);
+      const initial: Record<string, Position> = {};
+      data.forEach((t, i) => {
+        initial[t.id] = { x: (i % 5) * 120, y: Math.floor(i / 5) * 120 };
+      });
+      setPositions(initial);
+    };
+    fetchData();
+  }, []);
+
+  const handleDragEnd = (id: string, e: React.DragEvent<HTMLDivElement>) => {
+    const container = (e.currentTarget.parentElement as HTMLDivElement) ?? null;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    const x = e.clientX - rect.left - 50;
+    const y = e.clientY - rect.top - 50;
+    setPositions((prev) => ({ ...prev, [id]: { x, y } }));
+  };
+
+  const statusColor = (status: Table["status"]) => {
+    switch (status) {
+      case "available":
+        return "border-green-600 bg-green-50";
+      case "occupied":
+        return "border-red-600 bg-red-50";
+      case "reserved":
+        return "border-blue-600 bg-blue-50";
+      default:
+        return "border-gray-300 bg-gray-50";
+    }
+  };
+
+  return (
+    <RestaurantLayout>
+      <PermissionGuard page="table-layout">
+        <h1 className="text-2xl font-bold mb-4">Table Layout</h1>
+        <div className="relative w-full h-[600px] rounded-md border bg-white dark:bg-gray-800">
+          {tables.map((t) => (
+            <div
+              key={t.id}
+              draggable
+              onDragEnd={(e) => handleDragEnd(t.id, e)}
+              className={cn(
+                "absolute w-24 h-24 flex flex-col items-center justify-center rounded-md border-2 cursor-move select-none",
+                statusColor(t.status),
+              )}
+              style={{
+                left: positions[t.id]?.x ?? 0,
+                top: positions[t.id]?.y ?? 0,
+              }}
+            >
+              <span className="font-medium">Table {t.number}</span>
+              <Badge variant="outline" className="text-xs capitalize mt-1">
+                {t.status === "available" ? "open" : t.status}
+              </Badge>
+            </div>
+          ))}
+        </div>
+      </PermissionGuard>
+    </RestaurantLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `TableLayout` page to visually manage tables
- update role definitions and navigation to include table layout page
- register `TableLayout` route in the app
- test table layout page rendering and update permissions tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685dbc5f3850832cafd35179b88b5946