### PR TITLE
Fix iOS drag issue on table layout

### DIFF
--- a/src/pages/TableLayout.tsx
+++ b/src/pages/TableLayout.tsx
@@ -31,15 +31,6 @@ export default function TableLayout() {
     fetchData();
   }, []);
 
-  const handleDragEnd = (id: string, e: React.DragEvent<HTMLDivElement>) => {
-    const container = (e.currentTarget.parentElement as HTMLDivElement) ?? null;
-    if (!container) return;
-    const rect = container.getBoundingClientRect();
-    const x = e.clientX - rect.left - 50;
-    const y = e.clientY - rect.top - 50;
-    setPositions((prev) => ({ ...prev, [id]: { x, y } }));
-  };
-
   const handlePointerDown =
     (id: string) => (e: React.PointerEvent<HTMLDivElement>) => {
       const container =
@@ -87,15 +78,13 @@ export default function TableLayout() {
       <PermissionGuard page="table-layout">
         <h1 className="text-2xl font-bold mb-4">Table Layout</h1>
         <div
-          className="relative w-full h-[600px] rounded-md border bg-white dark:bg-gray-800"
+          className="relative w-full h-[600px] rounded-md border bg-white dark:bg-gray-800 touch-none"
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
         >
           {tables.map((t) => (
             <div
               key={t.id}
-              draggable
-              onDragEnd={(e) => handleDragEnd(t.id, e)}
               onPointerDown={handlePointerDown(t.id)}
               className={cn(
                 "absolute w-24 h-24 flex flex-col items-center justify-center rounded-md border-2 cursor-move select-none",


### PR DESCRIPTION
## Summary
- remove HTML drag handlers from table layout
- rely only on pointer events
- add `touch-none` to prevent iOS from hijacking gestures

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685e1ce2a3c4832cbc302f2a4ca07697