### PR TITLE
Implement table delete support

### DIFF
--- a/src/components/restaurant/TableLayoutView.spec.tsx
+++ b/src/components/restaurant/TableLayoutView.spec.tsx
@@ -1,8 +1,18 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { cleanup, render, screen } from "@/test-utils/react-testing-library";
 
 import { TableLayoutView } from "./TableLayoutView";
+
+vi.mock("@/hooks/use-permissions", () => ({
+  usePermissions: () => ({
+    hasPageAccess: () => true,
+    hasActionAccess: () => true,
+    getNavigationItems: () => [],
+    userRole: "Administrator",
+    currentUser: { role: "Administrator" },
+  }),
+}));
 
 afterEach(() => {
   cleanup();

--- a/src/components/restaurant/TableLayoutView.tsx
+++ b/src/components/restaurant/TableLayoutView.tsx
@@ -18,6 +18,8 @@ import { Table } from "@/lib/mock-data";
 import RestaurantService from "@/lib/restaurant-services";
 import { cn } from "@/lib/utils";
 
+import { PermissionGuard } from "./PermissionGuard";
+
 interface Position {
   x: number;
   y: number;
@@ -149,10 +151,12 @@ export function TableLayoutView() {
   return (
     <div className="space-y-2">
       <div className="flex justify-end">
-        <Button size="sm" onClick={openAddDialog}>
-          <Plus className="mr-2 h-4 w-4" />
-          Add Table
-        </Button>
+        <PermissionGuard page="tables" action="create">
+          <Button size="sm" onClick={openAddDialog}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add Table
+          </Button>
+        </PermissionGuard>
       </div>
       <div
         className="relative w-full h-[600px] rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 touch-none"
@@ -173,22 +177,26 @@ export function TableLayoutView() {
             }}
           >
             <div className="absolute top-1 right-1 flex space-x-1">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-5 w-5"
-                onClick={() => openEditDialog(t)}
-              >
-                <Edit className="h-3 w-3" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-5 w-5"
-                onClick={() => handleDelete(t.id)}
-              >
-                <Trash2 className="h-3 w-3" />
-              </Button>
+              <PermissionGuard page="tables" action="edit">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-5 w-5"
+                  onClick={() => openEditDialog(t)}
+                >
+                  <Edit className="h-3 w-3" />
+                </Button>
+              </PermissionGuard>
+              <PermissionGuard page="tables" action="delete">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-5 w-5"
+                  onClick={() => handleDelete(t.id)}
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+              </PermissionGuard>
             </div>
             <span className="font-medium">Table {t.number}</span>
             <Badge variant="outline" className="text-xs capitalize mt-1">

--- a/src/lib/restaurant-services.spec.ts
+++ b/src/lib/restaurant-services.spec.ts
@@ -1,15 +1,21 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { mockOrders } from "./mock-data";
+import { mockOrders, mockTables } from "./mock-data";
 import RestaurantService from "./restaurant-services";
 
 const originalOrders = JSON.parse(JSON.stringify(mockOrders));
+const originalTables = JSON.parse(JSON.stringify(mockTables));
 
 beforeEach(() => {
   mockOrders.splice(
     0,
     mockOrders.length,
     ...JSON.parse(JSON.stringify(originalOrders)),
+  );
+  mockTables.splice(
+    0,
+    mockTables.length,
+    ...JSON.parse(JSON.stringify(originalTables)),
   );
 });
 
@@ -38,5 +44,29 @@ describe("order utilities", () => {
     expect(mockOrders.length).toBe(originalLength - 1);
     expect(updated.items.length).toBeGreaterThanOrEqual(sourceItems);
     expect(mockOrders.find((o) => o.id === sourceId)).toBeUndefined();
+  });
+});
+
+describe("table utilities", () => {
+  it("creates a table", async () => {
+    const originalLength = mockTables.length;
+    const newTable = await RestaurantService.createTable({
+      number: 99,
+      capacity: 4,
+      status: "available",
+    });
+
+    expect(mockTables.length).toBe(originalLength + 1);
+    expect(mockTables.find((t) => t.id === newTable.id)).toBeDefined();
+  });
+
+  it("deletes a table", async () => {
+    const tableId = mockTables[0].id;
+    const originalLength = mockTables.length;
+
+    await RestaurantService.deleteTable(tableId);
+
+    expect(mockTables.length).toBe(originalLength - 1);
+    expect(mockTables.find((t) => t.id === tableId)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- restrict table management actions based on permissions
- add delete/create tests for table services
- mock permissions in TableLayoutView spec

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685e3b1f7618832c9de299138d46e3d3