### PR TITLE
Fix dragging limits for table layout

### DIFF
--- a/src/components/restaurant/TableLayoutView.tsx
+++ b/src/components/restaurant/TableLayoutView.tsx
@@ -16,7 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Table } from "@/lib/mock-data";
 import RestaurantService from "@/lib/restaurant-services";
-import { cn, pointsWithinDistance } from "@/lib/utils";
+import { clamp, cn, pointsWithinDistance } from "@/lib/utils";
 
 import { PermissionGuard } from "./PermissionGuard";
 
@@ -70,8 +70,12 @@ export function TableLayoutView() {
     if (!dragging) return;
     const container = e.currentTarget;
     const rect = container.getBoundingClientRect();
-    const x = e.clientX - rect.left - dragOffset.x;
-    const y = e.clientY - rect.top - dragOffset.y;
+    const rawX = e.clientX - rect.left - dragOffset.x;
+    const rawY = e.clientY - rect.top - dragOffset.y;
+    const maxX = rect.width - TABLE_SIZE;
+    const maxY = rect.height - TABLE_SIZE;
+    const x = clamp(rawX, 0, maxX);
+    const y = clamp(rawY, 0, maxY);
     setPositions((prev) => ({ ...prev, [dragging]: { x, y } }));
   };
 

--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { cn, pointsWithinDistance, rectanglesOverlap } from "./utils";
+import { clamp, cn, pointsWithinDistance, rectanglesOverlap } from "./utils";
 
 describe("cn function", () => {
   it("should merge classes correctly", () => {
@@ -53,5 +53,11 @@ describe("cn function", () => {
     const a = { x: 0, y: 0 };
     const b = { x: 100, y: 100 };
     expect(pointsWithinDistance(a, b, 60)).toBe(false);
+  });
+
+  it("should clamp values within range", () => {
+    expect(clamp(10, 0, 5)).toBe(5);
+    expect(clamp(-2, 0, 5)).toBe(0);
+    expect(clamp(3, 0, 5)).toBe(3);
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -30,3 +30,7 @@ export function pointsWithinDistance(
   const dy = a.y - b.y;
   return Math.hypot(dx, dy) < distance;
 }
+
+export function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}


### PR DESCRIPTION
## Summary
- prevent tables from being dragged outside the layout
- expose `clamp` util and tests

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685eedfd44a8832c8b88d0634272afbf