### PR TITLE
Fix mobile sidebar navigation

### DIFF
--- a/src/components/restaurant/RestaurantLayout.tsx
+++ b/src/components/restaurant/RestaurantLayout.tsx
@@ -117,6 +117,11 @@ export function RestaurantLayout({ children }: RestaurantLayoutProps) {
           const link = (
             <Link
               to={item.href}
+              onClick={() => {
+                if (isMobile) {
+                  setSidebarOpen(false);
+                }
+              }}
               className={cn(
                 "flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors",
                 isActive


### PR DESCRIPTION
## Summary
- close sidebar when tapping a navigation link on mobile

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685eee78dff4832ca203fbb1e15a0d15