### PR TITLE
Fix sidebar link routing issue

### DIFF
--- a/src/components/restaurant/RestaurantLayout.tsx
+++ b/src/components/restaurant/RestaurantLayout.tsx
@@ -18,12 +18,7 @@ import {
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Sheet,
-  SheetClose,
-  SheetContent,
-  SheetTrigger,
-} from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { useAuditLog } from "@/contexts/AuditLogContext";
 import { useUser } from "@/contexts/UserContext";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -134,13 +129,7 @@ export function RestaurantLayout({ children }: RestaurantLayoutProps) {
             </Link>
           );
 
-          return isMobile ? (
-            <SheetClose key={item.name} asChild>
-              {link}
-            </SheetClose>
-          ) : (
-            <span key={item.name}>{link}</span>
-          );
+          return <span key={item.name}>{link}</span>;
         })}
       </nav>
 


### PR DESCRIPTION
## Summary
- remove `SheetClose` wrapping from sidebar menu links
- update imports accordingly

## Testing
- `npm run format:fix`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ef15d7c30832cb0cec15de21b001b