### PR TITLE
Fix table layout overflow

### DIFF
--- a/src/components/restaurant/TableLayoutView.tsx
+++ b/src/components/restaurant/TableLayoutView.tsx
@@ -26,6 +26,7 @@ interface Position {
 }
 
 const TABLE_SIZE = 96;
+const ROOM_SIZE = 600;
 
 export function TableLayoutView() {
   const [tables, setTables] = useState<Table[]>([]);
@@ -42,8 +43,11 @@ export function TableLayoutView() {
       const data = await RestaurantService.getTables();
       setTables(data);
       const initial: Record<string, Position> = {};
+      const max = ROOM_SIZE - TABLE_SIZE;
       data.forEach((t, i) => {
-        initial[t.id] = { x: (i % 5) * 120, y: Math.floor(i / 5) * 120 };
+        const x = clamp((i % 5) * 120, 0, max);
+        const y = clamp(Math.floor(i / 5) * 120, 0, max);
+        initial[t.id] = { x, y };
       });
       setPositions(initial);
     };


### PR DESCRIPTION
## Summary
- prevent initial table placement outside of 600x600 room

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ef23618cc832c82a351c2ce84e172